### PR TITLE
Fix potential causes of 409 errors

### DIFF
--- a/gpu_reliability/platforms/gcp.py
+++ b/gpu_reliability/platforms/gcp.py
@@ -6,6 +6,7 @@ from gpu_reliability.stats_logger import StatsLogger, Stat
 from google.api_core.exceptions import NotFound
 from json import loads
 from gpu_reliability.logging import logger
+from uuid import uuid1
 
 
 @logger
@@ -44,7 +45,9 @@ class GCPPlatform(PlatformBase):
         return PlatformType.GCP
 
     def launch_instance(self, request: LaunchRequest):
-        instance_name = f"gpu-test-{int(time())}"
+        uuid = str(uuid1())
+        instance_name = f"gpu-test-{uuid}"
+
 
         instance = compute_v1.Instance(
             name=instance_name,
@@ -96,6 +99,7 @@ class GCPPlatform(PlatformBase):
             zone=request.geography,
             project=self.project_id,
             instance_resource=instance,
+            request_id=uuid,
         )
 
         # Wait for the create operation to complete.

--- a/gpu_reliability/platforms/gcp.py
+++ b/gpu_reliability/platforms/gcp.py
@@ -172,7 +172,7 @@ class GCPPlatform(PlatformBase):
                 # Only attempt to shut down running instances, otherwise we might clear away
                 # boxes that are still trying to bootstrap and/or have already started terminating.
                 if instance.status != "RUNNING":
-                    pass
+                    continue
                 self.logger.info(f"Deleting `{instance.name}`...")
                 operation = self.instance_client.delete(project=self.project_id, zone=zone, instance=instance.name)
                 try:


### PR DESCRIPTION
Fixing two potential causes of 409 errors.
The GCE API returns a 409 error on instances.insert when the name is already in use. Looking at this code this is either due to calling insert twice in the same second, or due to internal retries, either in the googleapis python code, or internal retries once Google has received the HTTP request.

This change adds a UUID into the instance name to make it unique, and uses that UUID as the requestId for the instances.insert call. This makes the call idempotent, and retries will all return the same operation rather than returning a 409.