### PR TITLE
Fix image for GCE test

### DIFF
--- a/gpu_reliability/platforms/gcp.py
+++ b/gpu_reliability/platforms/gcp.py
@@ -151,7 +151,7 @@ class GCPPlatform(PlatformBase):
 
     def get_image(self) -> compute_v1.Image:
         # List of public operating system (OS) images: https://cloud.google.com/compute/docs/images/os-details
-        newest_image = self.image_client.get_from_family(project="ubuntu-os-cloud", family="ubuntu-2204-lts-arm64")
+        newest_image = self.image_client.get_from_family(project="debian-cloud", family="debian-11")
         return newest_image
 
     def cleanup_resources(self):

--- a/gpu_reliability/platforms/gcp.py
+++ b/gpu_reliability/platforms/gcp.py
@@ -6,6 +6,7 @@ from gpu_reliability.stats_logger import StatsLogger, Stat
 from google.api_core.exceptions import NotFound
 from json import loads
 from gpu_reliability.logging import logger
+from uuid import uuid1
 
 
 @logger
@@ -44,7 +45,9 @@ class GCPPlatform(PlatformBase):
         return PlatformType.GCP
 
     def launch_instance(self, request: LaunchRequest):
-        instance_name = f"gpu-test-{int(time())}"
+        uuid = str(uuid1())
+        instance_name = f"gpu-test-{uuid}"
+
 
         instance = compute_v1.Instance(
             name=instance_name,
@@ -96,6 +99,7 @@ class GCPPlatform(PlatformBase):
             zone=request.geography,
             project=self.project_id,
             instance_resource=instance,
+            request_id=uuid,
         )
 
         # Wait for the create operation to complete.

--- a/gpu_reliability/platforms/gcp.py
+++ b/gpu_reliability/platforms/gcp.py
@@ -172,7 +172,7 @@ class GCPPlatform(PlatformBase):
                 # Only attempt to shut down running instances, otherwise we might clear away
                 # boxes that are still trying to bootstrap and/or have already started terminating.
                 if instance.status != "RUNNING":
-                    pass
+                    continue
                 self.logger.info(f"Deleting `{instance.name}`...")
                 operation = self.instance_client.delete(project=self.project_id, zone=zone, instance=instance.name)
                 try:


### PR DESCRIPTION
Fixing the image used by the GCE test - the previous code used an ARM image on an x86 instance, which doesn't boot. This code doesn't test guest boot times, but it will not hurt to use a functioning image if someone does try to add boot time support.