### PR TITLE
Two improvements for operation timing for both AWS and GCP.

### DIFF
--- a/gpu_reliability/platforms/aws.py
+++ b/gpu_reliability/platforms/aws.py
@@ -71,6 +71,7 @@ class AWSPlatform(PlatformBase):
 
         self.logger.info(f"Creating instance `{instance_name}`...")
 
+        start = time()
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.run_instances
         created_instance = client.run_instances(
             BlockDeviceMappings=[
@@ -113,7 +114,6 @@ class AWSPlatform(PlatformBase):
 
         instance_id = created_instance["Instances"][0]["InstanceId"]
 
-        start = time()
         instance, state_type = self.wait_for_status(
             instance_id,
             lambda x: x != AWSInstanceCodes.PENDING,
@@ -190,7 +190,7 @@ class AWSPlatform(PlatformBase):
         break_condition,
         max_wait: int,
         resource: Session.resource,
-        check_interval: int = 10,
+        check_interval: int = 1,
     ):
         instance = resource.Instance(instance_id)
         instance_name = self.name_from_instance(instance)

--- a/gpu_reliability/platforms/gcp.py
+++ b/gpu_reliability/platforms/gcp.py
@@ -1,7 +1,6 @@
-import functools
-
 from google.cloud import compute_v1
 from time import time
+from functools import partial
 from gpu_reliability.platforms.base import PlatformType, PlatformBase, LaunchRequest, INSTANCE_TAG, INSTANCE_TAG_VALUE
 from google.oauth2.service_account import Credentials
 from gpu_reliability.stats_logger import StatsLogger, Stat
@@ -109,7 +108,10 @@ class GCPPlatform(PlatformBase):
 
         start = time()
         operation = self.instance_client.insert(request=create_request)
-        wait_func = functools.partial(compute_v1.ZoneOperationsClient().wait, operation=operation.name, zone=request.geography, project=self.project_id)
+        # Until the GCE Client Library is fixed, replace the "get" method with "wait", which is a hanging call that returns
+        # when the operation is complete.
+        # Original call site: https://github.com/googleapis/python-api-core/blob/9abc6f48f23c87b9771dca3c96b4f6af39620a50/google/api_core/extended_operation.py#L142
+        wait_func = partial(compute_v1.ZoneOperationsClient().wait, operation=operation.name, zone=request.geography, project=self.project_id)
         operation._refresh = wait_func
         operation.result(timeout=self.create_timeout)
         create_time = time() - start

--- a/gpu_reliability/platforms/gcp.py
+++ b/gpu_reliability/platforms/gcp.py
@@ -6,6 +6,7 @@ from gpu_reliability.stats_logger import StatsLogger, Stat
 from google.api_core.exceptions import NotFound
 from json import loads
 from gpu_reliability.logging import logger
+from uuid import uuid1
 
 
 @logger
@@ -44,7 +45,9 @@ class GCPPlatform(PlatformBase):
         return PlatformType.GCP
 
     def launch_instance(self, request: LaunchRequest):
-        instance_name = f"gpu-test-{int(time())}"
+        uuid = str(uuid1())
+        instance_name = f"gpu-test-{uuid}"
+
 
         instance = compute_v1.Instance(
             name=instance_name,
@@ -96,6 +99,7 @@ class GCPPlatform(PlatformBase):
             zone=request.geography,
             project=self.project_id,
             instance_resource=instance,
+            request_id=uuid,
         )
 
         # Wait for the create operation to complete.

--- a/gpu_reliability/platforms/gcp.py
+++ b/gpu_reliability/platforms/gcp.py
@@ -172,7 +172,7 @@ class GCPPlatform(PlatformBase):
                 # Only attempt to shut down running instances, otherwise we might clear away
                 # boxes that are still trying to bootstrap and/or have already started terminating.
                 if instance.status != "RUNNING":
-                    pass
+                    continue
                 self.logger.info(f"Deleting `{instance.name}`...")
                 operation = self.instance_client.delete(project=self.project_id, zone=zone, instance=instance.name)
                 try:


### PR DESCRIPTION
Both: Measure create time including the initial HTTP request to create the VM. This was previously excluded, but is certainly part of the create time.

AWS: Reduce polling interval from 10s to 1s. The previous results had so little variance because the polling interval was longer than most VM creation times. This speeds up AWS quite noticeably.

GCE: Switch to using operation.wait instead of operation.get for operation polling, giving fast notice when VM creations are complete. The GCE client library used here uses an exponential backoff strategy that led to most of the variance being client-side sleeps. I've filed an internal bug and we're going to fix this. Thank you for helping us discover this bug.