### PR TITLE
Switch to larger GCP machine, hard-drive type

### DIFF
--- a/gpu_reliability/cli.py
+++ b/gpu_reliability/cli.py
@@ -61,7 +61,7 @@ def benchmark(
     platforms = [
         GCPPlatform(
             project_id=settings.gcp_project,
-            machine_type="n1-standard-1",
+            machine_type="n1-standard-4",
             accelerator_type="nvidia-tesla-t4",
             service_account=settings.gcp_service_account,
             storage=storage,


### PR DESCRIPTION
Address additional [boot suggestions](https://github.com/piercefreeman/cloud-gpu-reliability/issues/4) on GCP. Specifically, we switch to a more comparable VM to the AWS's g4dn.xlarge configuration. We pick the n1-standard-4 which provisions 4CPU/15GB memory compared to the 4CPU/16GB memory of the g4dn.xlarge.